### PR TITLE
fix validate_session query selection set

### DIFF
--- a/validate_session.go
+++ b/validate_session.go
@@ -1,6 +1,9 @@
 package authorizer
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // ValidateSessionInput defines attributes for validate_session request
 type ValidateSessionInput struct {
@@ -21,7 +24,7 @@ type ValidateSessionResponse struct {
 // For implementation details check ValidateSessionExample examples/validate_session.go
 func (c *AuthorizerClient) ValidateSession(req *ValidateSessionInput) (*ValidateSessionResponse, error) {
 	bytesData, err := c.ExecuteGraphQL(&GraphQLRequest{
-		Query: `query validateSession($data: ValidateSessionInput!){validate_session(params: $data) { is_valid user } }`,
+		Query: fmt.Sprintf(`query validateSession($data: ValidateSessionInput!){validate_session(params: $data) { is_valid user { %s } } }`, UserFragment),
 		Variables: map[string]interface{}{
 			"data": req,
 		},


### PR DESCRIPTION
## Description
This PR fixes a GraphQL validation error in the ValidateSession method.

## The Issue
The ValidateSession method was sending a GraphQL query that included the user field without a selection set: ... { validate_session(params: $data) { is_valid user } }

Because User is a composite object type in the Authorizer schema, the GraphQL specification requires an explicit selection of subfields. This caused the server to return the following error:

"Field 'user' of type 'User!' must have a selection of subfields. Did you mean "user { ... }"?"

## The Fix
Updated validate_session.go to use fmt.Sprintf and the existing UserFragment (defined in common.go). This ensures the query now correctly requests the standardized set of user subfields, satisfying the GraphQL requirements and matching the implementation pattern used in the Login and SignUp methods.

## Changes
* Added fmt import to validate_session.go
* Modified ValidateSession query string to include { %s } wrapper for the user field.