### PR TITLE
refactor: simplify headers loop by removing redundant nil check

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -45,10 +45,8 @@ func (c *AuthorizerClient) ExecuteGraphQL(req *GraphQLRequest, headers map[strin
 	}
 
 	// set the headers for this request
-	if headers != nil {
-		for key, val := range headers {
-			httpReq.Header.Add(key, val)
-		}
+	for key, val := range headers {
+		httpReq.Header.Add(key, val)
 	}
 
 	res, err := client.Do(httpReq)


### PR DESCRIPTION
## Summary
This PR removes a redundant if headers != nil check before iterating over the headers map in ExecuteGraphQL.

## Rationale
In Go, the range keyword is designed to safely handle nil maps and slices by performing zero iterations. Explicitly checking for nil before a range loop is unnecessary and deviates from idiomatic Go practices.

## Changes
* Cleaned up graphql.go by removing the outer conditional check for the headers parameter.
* No functional change; behavior remains identical for both nil and non-nil map inputs.
