### PR TITLE
Refactor: Replace ioutil ReadAll with io ReadAll

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -59,7 +59,7 @@ func (c *AuthorizerClient) ExecuteGraphQL(req *GraphQLRequest, headers map[strin
 	// Hence defer close. It will automatically take care of it.
 	defer res.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(res.Body)
+	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/revoke_token.go
+++ b/revoke_token.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -49,7 +49,7 @@ func (c *AuthorizerClient) RevokeToken(req *RevokeTokenInput) (*Response, error)
 	// Hence defer close. It will automatically take care of it.
 	defer httpRes.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(httpRes.Body)
+	bodyBytes, err := io.ReadAll(httpRes.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Replace calls to deprecated ioutil with io where appropriate.

## Work
Found two calls to ioutil.ReadAll that could be replaced directly with calls to io.ReadAll. Both were reads of an http response body which is a Reader.

## Changes
* graphql.go line 62
* revoke_token.go line 52