### PR TITLE
fix(security): fix ExtraHeaders bug and add HTTP client timeout

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,6 +46,6 @@ func NewAuthorizerClient(clientID, authorizerURL, redirectURL string, extraHeade
 		RedirectURL:   strings.TrimSuffix(redirectURL, "/"),
 		AuthorizerURL: strings.TrimSuffix(authorizerURL, "/"),
 		ClientID:      clientID,
-		ExtraHeaders:  extraHeaders,
+		ExtraHeaders:  headers,
 	}, nil
 }

--- a/graphql.go
+++ b/graphql.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"time"
 )
 
 // GraphQLRequest is object used to make graphql queries
@@ -30,7 +31,7 @@ func (c *AuthorizerClient) ExecuteGraphQL(req *GraphQLRequest, headers map[strin
 		return nil, err
 	}
 
-	client := http.Client{}
+	client := http.Client{Timeout: 30 * time.Second}
 	httpReq, err := http.NewRequest(http.MethodPost, c.AuthorizerURL+"/graphql", bytes.NewReader(jsonReq))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- **ExtraHeaders bug (HIGH)**: Fixed `NewAuthorizerClient` to use the enriched `headers` map (with `x-authorizer-url` and `x-authorizer-client-id`) instead of the raw `extraHeaders` parameter. Previously, default headers were never sent with requests.
- **HTTP timeout (MEDIUM)**: Added 30-second timeout to `http.Client` in GraphQL requests to prevent indefinite hangs.

## Files Changed
- `client.go` — ExtraHeaders assignment fix
- `graphql.go` — HTTP client timeout

## Test plan
- [ ] Verify SDK requests include `x-authorizer-url` and `x-authorizer-client-id` headers
- [ ] Verify requests timeout after 30 seconds when server is unresponsive