### PR TITLE
security(signup): remove IsMultiFactorAuthEnabled from SignUpRequest

### DIFF
--- a/signup.go
+++ b/signup.go
@@ -11,23 +11,22 @@ import (
 
 // SignUpRequest defines attributes for signup request
 type SignUpRequest struct {
-	Email                    *string                `json:"email,omitempty"`
-	Password                 string                 `json:"password"`
-	ConfirmPassword          string                 `json:"confirm_password"`
-	GivenName                *string                `json:"given_name,omitempty"`
-	FamilyName               *string                `json:"family_name,omitempty"`
-	MiddleName               *string                `json:"middle_name,omitempty"`
-	NickName                 *string                `json:"nick_name,omitempty"`
-	Picture                  *string                `json:"picture,omitempty"`
-	Gender                   *string                `json:"gender,omitempty"`
-	BirthDate                *string                `json:"birthdate,omitempty"`
-	PhoneNumber              *string                `json:"phone_number,omitempty"`
-	Roles                    []*string              `json:"roles,omitempty"`
-	Scope                    []*string              `json:"scope,omitempty"`
-	RedirectURI              *string                `json:"redirect_uri,omitempty"`
-	IsMultiFactorAuthEnabled *bool                  `json:"is_multi_factor_auth_enabled,omitempty"`
-	AppData                  map[string]interface{} `json:"app_data,omitempty"`
-	State                    *string                `json:"state,omitempty"`
+	Email           *string                `json:"email,omitempty"`
+	Password        string                 `json:"password"`
+	ConfirmPassword string                 `json:"confirm_password"`
+	GivenName       *string                `json:"given_name,omitempty"`
+	FamilyName      *string                `json:"family_name,omitempty"`
+	MiddleName      *string                `json:"middle_name,omitempty"`
+	NickName        *string                `json:"nick_name,omitempty"`
+	Picture         *string                `json:"picture,omitempty"`
+	Gender          *string                `json:"gender,omitempty"`
+	BirthDate       *string                `json:"birthdate,omitempty"`
+	PhoneNumber     *string                `json:"phone_number,omitempty"`
+	Roles           []*string              `json:"roles,omitempty"`
+	Scope           []*string              `json:"scope,omitempty"`
+	RedirectURI     *string                `json:"redirect_uri,omitempty"`
+	AppData         map[string]interface{} `json:"app_data,omitempty"`
+	State           *string                `json:"state,omitempty"`
 }
 
 // SignUpInput is deprecated: Use SignUpRequest instead


### PR DESCRIPTION
## Summary

Server PR authorizerdev/authorizer#710 (shipped in 2.4.0-rc.6) removed `is_multi_factor_auth_enabled` from `SignupRequest` entirely — GraphQL schema field gone, proto field 15 reserved — because it let an unauthenticated signup caller bypass the server's MFA-on-by-default policy for their own new account.

This SDK's own `SignUpRequest` struct (`signup.go`) still declared `IsMultiFactorAuthEnabled *bool` and forwarded it on every transport the `SignUp` method supports: as a GraphQL variable, as the REST request body, and via `remarshal` into the vendored gRPC stub. That's the client-side surface for the same bypass the server just closed, so it's removed here too.

- `go build ./...` and `go vet ./...` pass.
- No other hand-written code in the SDK references this field on signup (checked README, examples/, test/ — no hits).

## Scope note

The vendored proto stub under `internal/genpb/authorizer/v1/authorizer.pb.go` still declares `IsMultiFactorAuthEnabled` on the generated `SignupRequest` type — it hasn't been regenerated against the server's updated `.proto`. This repo has no `buf.gen.yaml` or regen script/Makefile target; past vendor refreshes here (e.g. 5ed5e36) were done as full hand-copied `.pb.go` replacements. Given the risk of hand-editing protoc-generated code (raw descriptor bytes, reflection metadata), I left that stub alone rather than touch it in this PR — it's functionally inert either way: proto3 omits zero-value scalar fields from the wire, and nothing in this SDK sets the field anymore, so no request will ever carry it. A full proto re-vendor pass against the new authorizer.proto is a separate follow-up.

This PR is scoped narrowly to the #710 fallout — it does not address any other SDK gaps from the earlier audit.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] `make test` (integration suite against a live authorizer container) — attempted locally but blocked by an unrelated port conflict (8080/9091 already bound by another local process on this machine); the change itself is a plain struct-field removal with no behavioral branches, verified by build/vet.