### PR TITLE
fix!: match the backend's standardized single-level pagination shape

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
             echo "These files need gofmt:"; echo "$unformatted"; exit 1
           fi
 
-      # make test starts the quay.io/authorizer/authorizer:2.4.0-rc.7 container
+      # make test starts the quay.io/authorizer/authorizer:2.4.0-rc.9 container
       # (docker is preinstalled on ubuntu-latest), runs the integration suite
       # across graphql/rest/grpc, then tears the container down.
       - name: Integration tests

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # 2. Run tests: make test
 
 # Docker image for authorizer server
-AUTHORIZER_IMAGE := quay.io/authorizer/authorizer:2.4.0-rc.7
+AUTHORIZER_IMAGE := quay.io/authorizer/authorizer:2.4.0-rc.9
 AUTHORIZER_CONTAINER := authorizer-test
 
 .PHONY: docker-up docker-down test

--- a/admin_methods.go
+++ b/admin_methods.go
@@ -31,16 +31,6 @@ const (
 	adminSamlIdpKeyFields    = `id org_id cert_pem algorithm status created_at updated_at`
 )
 
-// wrapPagination nests a proto PaginationRequest into the GraphQL
-// PaginatedRequest input shape ({pagination: {limit, page}}) used by the
-// ListClientsRequest / ListTrustedIssuersRequest inputs.
-func wrapPagination(p *authorizerv1.PaginationRequest) map[string]interface{} {
-	if p == nil {
-		return nil
-	}
-	return map[string]interface{}{"pagination": p}
-}
-
 // ---------------------------------------------------------------------------
 // 1. AdminLogin — establishes an admin session. grpc, rest, gql.
 // ---------------------------------------------------------------------------
@@ -251,8 +241,8 @@ func (c *AuthorizerAdminClient) VerificationRequests(req *authorizerv1.Verificat
 	err := c.execute(adminMethodSpec{
 		name: "VerificationRequests",
 		graphql: &GraphQLRequest{
-			Query:     "query verificationRequests($data: PaginatedRequest) { _verification_requests(params: $data) { " + adminPaginationFields + " verification_requests { " + adminVerifReqFields + " } } }",
-			Variables: map[string]interface{}{"data": req},
+			Query:     "query verificationRequests($data: PaginationRequest) { _verification_requests(params: $data) { " + adminPaginationFields + " verification_requests { " + adminVerifReqFields + " } } }",
+			Variables: map[string]interface{}{"data": req.GetPagination()},
 		},
 		graphqlField: "_verification_requests",
 		restMethod:   http.MethodPost,
@@ -468,8 +458,8 @@ func (c *AuthorizerAdminClient) Webhooks(req *authorizerv1.WebhooksRequest) (*au
 	err := c.execute(adminMethodSpec{
 		name: "Webhooks",
 		graphql: &GraphQLRequest{
-			Query:     "query webhooks($data: PaginatedRequest) { _webhooks(params: $data) { " + adminPaginationFields + " webhooks { " + adminWebhookFields + " } } }",
-			Variables: map[string]interface{}{"data": req},
+			Query:     "query webhooks($data: PaginationRequest) { _webhooks(params: $data) { " + adminPaginationFields + " webhooks { " + adminWebhookFields + " } } }",
+			Variables: map[string]interface{}{"data": req.GetPagination()},
 		},
 		graphqlField: "_webhooks",
 		restMethod:   http.MethodPost,
@@ -631,8 +621,8 @@ func (c *AuthorizerAdminClient) EmailTemplates(req *authorizerv1.EmailTemplatesR
 	err := c.execute(adminMethodSpec{
 		name: "EmailTemplates",
 		graphql: &GraphQLRequest{
-			Query:     "query emailTemplates($data: PaginatedRequest) { _email_templates(params: $data) { " + adminPaginationFields + " email_templates { " + adminEmailTplFields + " } } }",
-			Variables: map[string]interface{}{"data": req},
+			Query:     "query emailTemplates($data: PaginationRequest) { _email_templates(params: $data) { " + adminPaginationFields + " email_templates { " + adminEmailTplFields + " } } }",
+			Variables: map[string]interface{}{"data": req.GetPagination()},
 		},
 		graphqlField: "_email_templates",
 		restMethod:   http.MethodPost,
@@ -1031,12 +1021,9 @@ func (c *AuthorizerAdminClient) GetClient(req *authorizerv1.GetClientRequest) (*
 
 // Clients returns a paginated list of clients.
 func (c *AuthorizerAdminClient) Clients(req *authorizerv1.ClientsRequest) (*authorizerv1.ClientsResponse, error) {
-	// The GraphQL ListClientsRequest nests pagination one level deeper than the
-	// proto shape ({pagination: {pagination: {...}}}), so the variables are
-	// built explicitly instead of passing req through.
 	gqlData := map[string]interface{}{}
 	if req.GetPagination() != nil {
-		gqlData["pagination"] = wrapPagination(req.GetPagination())
+		gqlData["pagination"] = req.GetPagination()
 	}
 
 	var res authorizerv1.ClientsResponse
@@ -1180,11 +1167,9 @@ func (c *AuthorizerAdminClient) GetTrustedIssuer(req *authorizerv1.GetTrustedIss
 // TrustedIssuers returns a paginated list of trusted issuers, optionally
 // filtered by service account.
 func (c *AuthorizerAdminClient) TrustedIssuers(req *authorizerv1.TrustedIssuersRequest) (*authorizerv1.TrustedIssuersResponse, error) {
-	// The GraphQL ListTrustedIssuersRequest nests pagination one level deeper
-	// than the proto shape, so the variables are built explicitly.
 	gqlData := map[string]interface{}{}
 	if req.GetPagination() != nil {
-		gqlData["pagination"] = wrapPagination(req.GetPagination())
+		gqlData["pagination"] = req.GetPagination()
 	}
 	if req.ServiceAccountId != nil {
 		gqlData["service_account_id"] = req.GetServiceAccountId()
@@ -1331,11 +1316,9 @@ func (c *AuthorizerAdminClient) GetSamlServiceProvider(req *authorizerv1.GetSaml
 
 // ListSamlServiceProviders returns a paginated list of downstream SPs for an org.
 func (c *AuthorizerAdminClient) ListSamlServiceProviders(req *authorizerv1.ListSamlServiceProvidersRequest) (*authorizerv1.ListSamlServiceProvidersResponse, error) {
-	// The GraphQL ListSAMLServiceProvidersRequest nests pagination one level
-	// deeper than the proto shape, so the variables are built explicitly.
 	gqlData := map[string]interface{}{"org_id": req.GetOrgId()}
 	if req.GetPagination() != nil {
-		gqlData["pagination"] = wrapPagination(req.GetPagination())
+		gqlData["pagination"] = req.GetPagination()
 	}
 
 	var res authorizerv1.ListSamlServiceProvidersResponse
@@ -1577,11 +1560,6 @@ type PaginationRequest struct {
 	Page  int64 `json:"page,omitempty"`
 }
 
-// PaginatedRequest mirrors the GraphQL PaginatedRequest input.
-type PaginatedRequest struct {
-	Pagination *PaginationRequest `json:"pagination,omitempty"`
-}
-
 // Pagination mirrors the GraphQL Pagination response type.
 type Pagination struct {
 	Limit  int64 `json:"limit"`
@@ -1647,7 +1625,7 @@ type OrganizationRequest struct {
 
 // ListOrganizationsRequest is the request for Organizations.
 type ListOrganizationsRequest struct {
-	Pagination *PaginatedRequest `json:"pagination,omitempty"`
+	Pagination *PaginationRequest `json:"pagination,omitempty"`
 }
 
 // AddOrgMemberRequest is the request for AddOrgMember. Roles defaults to an
@@ -1666,8 +1644,8 @@ type RemoveOrgMemberRequest struct {
 
 // ListOrgMembersRequest is the request for OrgMembers.
 type ListOrgMembersRequest struct {
-	OrgID      string            `json:"org_id"`
-	Pagination *PaginatedRequest `json:"pagination,omitempty"`
+	OrgID      string             `json:"org_id"`
+	Pagination *PaginationRequest `json:"pagination,omitempty"`
 }
 
 // CreateOrganization creates an organization (gql only).
@@ -2118,8 +2096,8 @@ type AddVerifiedOrgDomainRequest struct {
 
 // ListOrgDomainsRequest is the request for OrgDomains.
 type ListOrgDomainsRequest struct {
-	OrgID      string            `json:"org_id"`
-	Pagination *PaginatedRequest `json:"pagination,omitempty"`
+	OrgID      string             `json:"org_id"`
+	Pagination *PaginationRequest `json:"pagination,omitempty"`
 }
 
 // DeleteOrgDomainRequest is the request for DeleteOrgDomain.


### PR DESCRIPTION
## Summary

The Authorizer backend removed the `PaginatedRequest` wrapper type entirely (see the corresponding `authorizerdev/authorizer` PR — a `fix(graphql)!` breaking-change commit standardizing GraphQL pagination on `PaginationRequest` directly, matching the proto/gRPC surface, which never had a double-wrapper in the first place).

Two places in this SDK were affected — both GraphQL-transport-only (REST and gRPC use the proto message shapes directly and were never affected by the old GraphQL-schema-only wrapper):

- **`VerificationRequests`/`Webhooks`/`EmailTemplates`**: hardcoded `$data: PaginatedRequest` in their query strings and passed the whole proto request (itself just a `Pagination` wrapper) as the GraphQL variable — now `$data: PaginationRequest`, passing `req.GetPagination()` directly.
- **`Clients`/`TrustedIssuers`/`ListSamlServiceProviders`**: used a `wrapPagination` helper to double-nest the proto `PaginationRequest` into `{pagination: {pagination: {...}}}` for the GraphQL variables — the helper is removed, the proto pagination now passes through as-is.
- **`ListOrganizationsRequest`/`ListOrgMembersRequest`/`ListOrgDomainsRequest`** (this SDK's own Go-native request types, not proto-generated): their `Pagination` field was typed `*PaginatedRequest`, requiring callers to double-nest by hand — now `*PaginationRequest` directly. **Breaking change** for any caller constructing these types with a nested `Pagination`.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l .` clean
- [x] Verified against a locally built `authorizer` image running the backend fix (not yet released): full `go test ./...` passes across all three transports (graphql, rest, grpc) — including the admin pagination suite (`TestAdminUsersAcrossProtocols`, `TestAdminWebhookLifecycle`, `TestAdminFgaModelAndTuples`) and the full protocol/auth suite

**Please coordinate merging/releasing this alongside the backend fix** — until the backend PR ships, this SDK version would send a shape the currently-deployed backend rejects.