### PR TITLE
fix!: add required /v2 module path suffix

### DIFF
--- a/examples/deactivate_account.go
+++ b/examples/deactivate_account.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // DeactivateAccountExample demonstrates how to use DeactivateAccount function of authorizer sdk

--- a/examples/forgot_password.go
+++ b/examples/forgot_password.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // ForgotPasswordInputExample demonstrates how to use ForgotPassword function of authorizer skd

--- a/examples/get_meta_data.go
+++ b/examples/get_meta_data.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // GetMetaDataExample demonstrates how to use GetMetaData function of authorizer sdk

--- a/examples/get_profile.go
+++ b/examples/get_profile.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // GetProfileExample demonstrates how to use GetProfile function of authorizer sdk

--- a/examples/get_session.go
+++ b/examples/get_session.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // GetSessionExample demonstrates how to use GetSession function of authorizer sdk

--- a/examples/login.go
+++ b/examples/login.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // LoginExample demonstrates how to use Login function of authorizer sdk

--- a/examples/logout.go
+++ b/examples/logout.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // LogoutExample demonstrates how to use Logout function of authorizer sdk

--- a/examples/magic_link_login.go
+++ b/examples/magic_link_login.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // MagicLinkLoginExample demonstrates how to use MagicLinkLogin function of authorizer sdk

--- a/examples/manual/main.go
+++ b/examples/manual/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 	authorizerv1 "github.com/authorizerdev/authorizer-proto-go/authorizer/v1"
 )
 

--- a/examples/resend_otp.go
+++ b/examples/resend_otp.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // ResendOTPExample demonstrates how to use ResendOTP function of authorizer sdk

--- a/examples/resend_verify_email.go
+++ b/examples/resend_verify_email.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // ResendVerifyEmailExample demonstrates how to use ResendVerifyEmail function of authorizer sdk

--- a/examples/reset_password.go
+++ b/examples/reset_password.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // ResetPasswordExample demonstrates how to use ResetPassword function of authorizer sdk

--- a/examples/revoke_token.go
+++ b/examples/revoke_token.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // RevokeTokenExample demonstrates how to use RevokeToken function of authorizer sdk

--- a/examples/signup.go
+++ b/examples/signup.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // SignUpExample demonstrates how to use SignUp function of authorizer sdk

--- a/examples/update_profile.go
+++ b/examples/update_profile.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // UpdateProfileExample demonstrates how to use UpdateProfile function of authorizer sdk

--- a/examples/validate_jwt_token.go
+++ b/examples/validate_jwt_token.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // ValidateJWTTokenExample demonstrates how to use ValidateJWTToken function of authorizer sdk

--- a/examples/validate_session.go
+++ b/examples/validate_session.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // ValidateSessionExample demonstrates how to use ValidateSession function of authorizer sdk

--- a/examples/verify_email.go
+++ b/examples/verify_email.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // VerifyEmailExample demonstrates how to use VerifyEmail function of authorizer sdk

--- a/examples/verify_otp.go
+++ b/examples/verify_otp.go
@@ -3,7 +3,7 @@ package examples
 import (
 	"fmt"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // VerifyOTPExample demonstrates how to use VerifyOTP function of authorizer sdk

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/authorizerdev/authorizer-go
+module github.com/authorizerdev/authorizer-go/v2
 
 go 1.25.5
 

--- a/test/admin_test.go
+++ b/test/admin_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 	authorizerv1 "github.com/authorizerdev/authorizer-proto-go/authorizer/v1"
 )
 

--- a/test/authorizer_test.go
+++ b/test/authorizer_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // Integration-test target. Overridable via env so the same suite runs against a

--- a/test/get_token_unit_test.go
+++ b/test/get_token_unit_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 	authorizerv1 "github.com/authorizerdev/authorizer-proto-go/authorizer/v1"
 )
 

--- a/test/main.go
+++ b/test/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/authorizerdev/authorizer-go/examples"
+import "github.com/authorizerdev/authorizer-go/v2/examples"
 
 func main() {
 	// examples.LoginExample()

--- a/test/protocol_test.go
+++ b/test/protocol_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/authorizerdev/authorizer-go"
+	"github.com/authorizerdev/authorizer-go/v2"
 )
 
 // protocols is the set of wire transports the public client supports. Each


### PR DESCRIPTION
## Summary
This module has been tagged v2.x since v2.0.0, but `go.mod` never added the `/v2` suffix Go's module versioning rules require for major version 2+. Confirmed via the module proxy: no v2.x tag has ever actually resolved for a consumer running a plain `go get github.com/authorizerdev/authorizer-go@v2.x.x` — it fails with "module contains a go.mod file, so module path must match major version".

## What changed
- `go.mod`: `module github.com/authorizerdev/authorizer-go` → `module github.com/authorizerdev/authorizer-go/v2`
- All internal self-references (25 files under `test/`, `examples/`) updated to the new import path.

**Breaking, but not newly breaking anyone with a working build** — v2.x import lines were never resolvable in the first place, so this makes v2.x installable for the first time rather than changing behavior for anyone currently depending on it successfully.

## Test plan
- [x] `go build`/`go vet`/`gofmt` clean
- [x] Full `go test ./...` — including the live integration suite across graphql/rest/grpc, public+admin — passes against a locally built `authorizer:localmain` image